### PR TITLE
Update to python-linstor-1.19.0

### DIFF
--- a/SOURCES/python-linstor-1.19.0.tar.gz
+++ b/SOURCES/python-linstor-1.19.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5515b434cd9032570ff410ded0a1ea30c4057654d5fe312fefe4e41697c08ce6
+size 88321

--- a/SOURCES/setup.py-python2.patch
+++ b/SOURCES/setup.py-python2.patch
@@ -1,0 +1,20 @@
+This patch removes the extras_require entry in setup.py for the enum34
+package. This entry generates an error with the old version of setuptools
+used in the build container for xcp-ng 8.2 and is not needed since
+setuptool is not used to generate the spec file.
+
+---
+diff --git a/setup.py b/setup.py
+index 60b74ac..26e02be 100755
+--- a/setup.py
++++ b/setup.py
+@@ -116,9 +116,6 @@ setup(
+         'Programming Language :: Python :: 3.8',
+         'Programming Language :: Python :: 3.9',
+     ],
+-    extras_require={
+-        ":python_version<'3'": ['enum34'],
+-    },
+     packages=[
+         'linstor'
+     ],

--- a/SPECS/python-linstor.spec
+++ b/SPECS/python-linstor.spec
@@ -1,0 +1,41 @@
+Summary: Linstor python api
+Name:    python-linstor
+Version: 1.19.0
+Release: 1%{?dist}
+License: LGPLv3
+URL:     https://linbit.com/linstor/
+
+BuildArch: noarch
+
+Source0: https://pkg.linbit.com//downloads/linstor/%{name}-%{version}.tar.gz
+
+# The build container for XCP-ng 8.2 doesn't have python3, so python3 available
+# means we're building for XCP-ng >= 8.3 and thus we use python3.
+%if "%(which python3 2>/dev/null)"
+%define python "python3"
+BuildRequires: python3-setuptools
+%else
+%define python "python2"
+Patch0: setup.py-python2.patch
+BuildRequires: python-setuptools python-enum34
+Requires: python-enum34
+%endif
+
+%description
+This repository contains a Python library to communicate with a linstor controller.
+
+%prep
+%autosetup -p1
+
+%build
+PYTHON=%{python} %{python} ./setup.py build
+
+%install
+PYTHON=%{python} %{python} ./setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+
+%files -f INSTALLED_FILES
+%license COPYING
+
+%changelog
+* Tue Nov 7 2023 Thierry Escande <thierry.escande@vates.tech> - 1.19.0-1
+- Update to python-linstor-1.19.0


### PR DESCRIPTION
This adds source archive and spec file for python-linstor v1.19.0.

The spec file targets both xcp-ng 8.2 and 8.3, using python 2 and python 3 respectively. In order to build the package using python 3 for xcp-ng 8.3, the spec file relies on the presence of the python3 executable which is only present in the xcp-ng 8.3 build container. The python 2 version for xcp-ng 8.2 is built otherwise.

The setup.py file is patched when building using python 2 for an extras_require entry not recognized by the old setuptool version used in the 8.2 build container.