### PR TITLE
8.3: Update to python-linstor-1.19.0

### DIFF
--- a/SOURCES/python-linstor-1.19.0.tar.gz
+++ b/SOURCES/python-linstor-1.19.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5515b434cd9032570ff410ded0a1ea30c4057654d5fe312fefe4e41697c08ce6
+size 88321

--- a/SPECS/python-linstor.spec
+++ b/SPECS/python-linstor.spec
@@ -1,0 +1,33 @@
+Summary: Linstor python api
+Name:    python-linstor
+Version: 1.19.0
+Release: 1%{?dist}
+License: LGPLv3
+URL:     https://linbit.com/linstor/
+
+BuildArch: noarch
+BuildRequires: python3-devel
+BuildRequires: python3-setuptools
+
+Source0: https://pkg.linbit.com/downloads/linstor/%{name}-%{version}.tar.gz
+
+%description
+This repository contains a Python library to communicate with a linstor controller.
+
+%prep
+%autosetup -p1
+
+%build
+PYTHON=%{__python3} %{__python3} ./setup.py build
+
+%install
+PYTHON=%{__python3} %{__python3} ./setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+
+%files -f INSTALLED_FILES
+
+%license COPYING
+%doc README.md
+
+%changelog
+* Tue Nov 07 2023 Thierry Escande <thierry.escande@vates.tech> - 1.19.0-1
+- Update to python-linstor-1.19.0


### PR DESCRIPTION
This commit adds source archive and spec file for python-linstor v1.19.0. The package is built using python 3 and targets xcp-ng 8.3.